### PR TITLE
Fix abnormal panicking due to missing if statement

### DIFF
--- a/src/raft_node.rs
+++ b/src/raft_node.rs
@@ -423,6 +423,10 @@ impl<S: Store + 'static + Send> RaftNode<S> {
     ) -> Result<()> {
         // Fitler out empty entries produced by new elected leaders.
         for entry in committed_entries {
+            if entry.get_data().is_empty() {
+                continue;
+            }
+
             if let EntryType::EntryConfChange = entry.get_entry_type() {
                 self.handle_config_change(&entry, client_send).await?;
             } else {


### PR DESCRIPTION
Hello, I'm currently working on writing [Python bindings](https://github.com/lablup/riteraft-py) of this crate (although it's not working yet)

I noticed that the example code was not functioning in the riteraft dev branch, so I added an if statement that seemed to be missing by mistake.

I mistakenly thought that the issue was caused by updating tokio, as the program was quietly panicked without any warning messages at first. But, it appears that this issue is not related to the tokio update. The bug occurs when the `context` of the first entry is an empty slice, which cannot be deserialized to the `u64`.

You can check that the program panicked at that line by replacing that line's `?` with `unwrap`.

https://github.com/ritelabs/riteraft/blob/dev/src/raft_node.rs#L495

I have checked that the example code in the dev branch is working properly with raft-rs 0.7.0